### PR TITLE
Added client_port and disover_client_host.

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -26,6 +26,8 @@ RUN touch /usr/local/etc/php/conf.d/php.ini; \
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
 	echo xdebug.mode=debug >> /usr/local/etc/php/conf.d/xdebug.ini; \
   	echo xdebug.client_host=host.docker.internal >> /usr/local/etc/php/conf.d/xdebug.ini; \
+	echo xdebug.client_port=9003 >> /usr/local/etc/php/conf.d/xdebug.ini; \
+	echo xdebug.discover_client_host=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
   	echo xdebug.idekey=PHPSTORM >> /usr/local/etc/php/conf.d/xdebug.ini; \
   	echo xdebug.remote_handler=dbgp >> /usr/local/etc/php/conf.d/xdebug.ini; \
   	echo xdebug.start_with_request=trigger >> /usr/local/etc/php/conf.d/xdebug.ini; \


### PR DESCRIPTION
Should prevent "NOTICE: PHP message: Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port) :-("