### PR TITLE
Prevent xdebug message: couldnt connect to client

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -22,16 +22,15 @@ RUN apt-get update -y && \
 RUN touch /usr/local/etc/php/conf.d/php.ini; \
         echo memory_limit=-1 >> /usr/local/etc/php/conf.d/php.ini
 
-# configure xdebug
+# configure xdebug & timezone
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
-	echo xdebug.mode=debug >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo xdebug.client_host=host.docker.internal >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo xdebug.idekey=PHPSTORM >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo xdebug.remote_handler=dbgp >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo xdebug.start_with_request=trigger >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo xdebug.output_dir=/var/www/html/ >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo xdebug.trigger_value="XDEBUG_PROFILE" >> /usr/local/etc/php/conf.d/xdebug.ini; \
-  	echo date.timezone = Europe/Berlin >> /usr/local/etc/php/conf.d/timezone.ini
+    echo xdebug.mode=debug                       >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.client_host=host.docker.internal >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.start_with_request=trigger       >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.trigger_value="XDEBUG_PROFILE"   >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.idekey=PHPSTORM                  >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.output_dir=/var/www/html/        >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo date.timezone = Europe/Berlin           >> /usr/local/etc/php/conf.d/timezone.ini
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 


### PR DESCRIPTION
NOTICE: PHP message: Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port) :-(.

Make sure the browser plugin 'Xdebug helper' is activated and as IDE key PHPStorm (according to the Docker config). Also the debugging config of the IDE has to be configured. The IDE has to listen for PHP Debug Connections all the time. That means also: be sure to uncheck the config: 'Break at first line in PHP Scripts'.